### PR TITLE
Remoção de configurações desnecessárias do módulo do axios

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -48,8 +48,6 @@ export default {
   // Axios module configuration: https://go.nuxtjs.dev/config-axios
   axios: {
     baseUrl: 'http://localhost:8080',
-    credentials: false,
-    proxyHeaders: false,
   },
 
   // Vuetify module configuration: https://go.nuxtjs.dev/config-vuetify

--- a/pages/inspire.vue
+++ b/pages/inspire.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <h1>nome do cliente - {{ cliente.nome }}</h1>
+    <h2>cpf do cliente - {{ cliente.cpf }}</h2>
   </div>
 </template>
 
@@ -8,11 +9,11 @@
 export default {
   data() {
     return {
-      cliente: { nome: '' },
+      cliente: {},
     }
   },
-  created() {
-    this.cliente = this.$axios.$get('/clientes/1')
+  async fetch() {
+    this.cliente = await this.$axios.$get('/clientes/1')
   },
 }
 </script>


### PR DESCRIPTION
Removi do nuxt.config.js os atributos que havíamos adicionado ao módulo do axios, além de fazer uma pequena correção na página de inspire. 

Como na página estamos indo no banco de dados buscar as informações do cliente, devemos fazê-lo no dentro do fetch() que trabalha com dados assíncronos (dados que necessitam de um tempo de 'espera' para obter a informação). O hook created() do vue não trabalha  com essas operações assíncronas. Seguem dois links interessantes onde explicam os hooks do Vue e os hooks personalizados do Nuxt para trabalhar com obtenção de dados assíncronos.

https://vuejs.org/v2/api/#Options-Lifecycle-Hooks
https://vuejs.org/v2/guide/instance.html#Lifecycle-Diagram
https://nuxtjs.org/docs/2.x/features/data-fetching
